### PR TITLE
🎨 Palette: Improve keyboard accessibility and form UX

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-14 - Keyboard-Driven Form Submission Pattern
+**Learning:** Modern desktop applications often miss standard keyboard interactions like pressing "Enter" to submit a form when high-level bindings are manually implemented. GTK provides `activates-default` and `default-widget` properties specifically for this.
+**Action:** Always ensure `setActivatesDefault(true)` is called on primary entry fields and `setDefaultWidget(button)` is set on the window's primary action button to maintain user expectations for keyboard accessibility.

--- a/examples/widgets-demo.ts
+++ b/examples/widgets-demo.ts
@@ -47,6 +47,15 @@ class WidgetsDemoWindow {
     // Create header bar and set it as the window's titlebar
     const headerBar = new HeaderBar();
 
+    const aboutButton = new Button();
+    aboutButton.setIconName("help-about-symbolic");
+    aboutButton.setTooltipText("About this application");
+    aboutButton.setAccessibleLabel("About");
+    aboutButton.onClick(() => {
+      this.#updateOutput("About button clicked!");
+    });
+    headerBar.packEnd(aboutButton);
+
     this.#win.setTitlebar(headerBar);
 
     // Create toolbar view for content
@@ -143,8 +152,10 @@ class WidgetsDemoWindow {
     const entry = new Entry();
     entry.setPlaceholderText("Type something here...");
     entry.setHexpand(true);
+    entry.setActivatesDefault(true);
 
     const submitButton = new Button("Submit");
+    this.#win.setDefaultWidget(submitButton);
     submitButton.onClick(() => {
       const text = entry.getText();
       if (text) {

--- a/src/high/gtk4.ts
+++ b/src/high/gtk4.ts
@@ -255,6 +255,14 @@ export class Widget extends GObject {
   isVisible(): boolean {
     return gtk4.symbols.gtk_widget_is_visible(this.ptr);
   }
+
+  setAccessibleLabel(label: string): void {
+    this.setProperty("accessible-label", label);
+  }
+
+  setAccessibleDescription(description: string): void {
+    this.setProperty("accessible-description", description);
+  }
 }
 
 export class ExpanderRow extends Widget {
@@ -464,6 +472,13 @@ export class Window extends Widget {
 
   addAction(action: SimpleAction): void {
     gio.symbols.g_action_map_add_action(this.ptr, action.ptr);
+  }
+
+  setDefaultWidget(widget: Widget | null): void {
+    gtk4.symbols.gtk_window_set_default_widget(
+      this.ptr,
+      widget ? widget.ptr : null,
+    );
   }
 }
 
@@ -1108,6 +1123,10 @@ export class Entry extends Widget {
   // High-level signal connection for changed
   onChanged(callback: () => void): number {
     return this.connect("changed", callback);
+  }
+
+  setActivatesDefault(activatesDefault: boolean): void {
+    gtk4.symbols.gtk_entry_set_activates_default(this.ptr, activatesDefault);
   }
 }
 

--- a/src/low/gtk4.ts
+++ b/src/low/gtk4.ts
@@ -698,4 +698,12 @@ export const gtk4 = Deno.dlopen(LIB_PATHS.gtk4, {
     parameters: ["pointer", "f64"],
     result: "void",
   },
+  gtk_window_set_default_widget: {
+    parameters: ["pointer", "pointer"],
+    result: "void",
+  },
+  gtk_entry_set_activates_default: {
+    parameters: ["pointer", "bool"],
+    result: "void",
+  },
 });


### PR DESCRIPTION
💡 What: 
- Implemented the "Enter to submit" UX pattern by adding support for `activates-default` on entry fields and `default-widget` on windows.
- Added an icon-only "About" button to the demo application's header bar.
- Added infrastructure for setting accessible labels and descriptions on all widgets.

🎯 Why: 
- Improves form usability by allowing users to submit with the keyboard.
- Enhances accessibility for icon-only elements as per Palette's core mission.

♿ Accessibility: 
- Icon-only buttons now have proper `accessible-label` properties.
- Improved keyboard navigation with default action support.

---
*PR created automatically by Jules for task [14260230774360665369](https://jules.google.com/task/14260230774360665369) started by @sigmaSd*