### PR TITLE
Add brightness control app using DDC/CI

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -20,7 +20,7 @@
     ]
   },
   "imports": {
-    "@sigma/deno-compat": "jsr:@sigma/deno-compat@0.22.0"
+    "@sigma/deno-compat": "jsr:@sigma/deno-compat@0.23.0"
   },
   "tasks": {
     "test": "deno lint && deno check && deno test --allow-ffi --allow-env && bun test && npm i && node --test"

--- a/examples/brightness-control.ts
+++ b/examples/brightness-control.ts
@@ -12,7 +12,7 @@ import {
   Scale,
 } from "@sigmasd/gtk/gtk4";
 import { HeaderBar, ToolbarView } from "@sigmasd/gtk/adw";
-import { DBusProxy, BusType, DBusProxyFlags } from "@sigmasd/gtk/gio";
+import { BusType, DBusProxy, DBusProxyFlags } from "@sigmasd/gtk/gio";
 import { EventLoop } from "@sigmasd/gtk/eventloop";
 
 const APP_ID = "com.example.BrightnessControl";
@@ -25,7 +25,7 @@ interface DDCMonitor {
   name: string;
 }
 
-async function getDBusProxy(): Promise<DBusProxy> {
+function getDBusProxy(): Promise<DBusProxy> {
   const proxy = DBusProxy.newForBusSync(
     BusType.SYSTEM,
     DBusProxyFlags.NONE,
@@ -35,15 +35,15 @@ async function getDBusProxy(): Promise<DBusProxy> {
     DDC_IFACE,
   );
   if (!proxy) throw new Error("Failed to create D-Bus proxy");
-  return proxy;
+  return Promise.resolve(proxy);
 }
 
-async function getMonitors(proxy: DBusProxy): Promise<DDCMonitor[]> {
+function getMonitors(proxy: DBusProxy): Promise<DDCMonitor[]> {
   const result = proxy.callSyncWithStrings("GetMonitors");
-  if (!result) return [];
+  if (!result) return Promise.resolve([]);
 
   const devices = result.getChildValue(0);
-  if (!devices) return [];
+  if (!devices) return Promise.resolve([]);
 
   const devicesList = devices.getStrv();
   const monitors: DDCMonitor[] = [];
@@ -72,25 +72,32 @@ async function getMonitors(proxy: DBusProxy): Promise<DDCMonitor[]> {
     }
   }
 
-  return monitors;
+  return Promise.resolve(monitors);
 }
 
-async function getBrightness(proxy: DBusProxy, device: string): Promise<{ result: number; value: number; max: number }> {
+function getBrightness(
+  proxy: DBusProxy,
+  device: string,
+): Promise<{ result: number; value: number; max: number }> {
   const result = proxy.callSyncWithMixed("GetControl", device, 16);
-  if (!result) return { result: -1, value: 0, max: 100 };
+  if (!result) return Promise.resolve({ result: -1, value: 0, max: 100 });
 
   const resultCode = result.getChildValue(0)?.getInt32() ?? -1;
   const value = result.getChildValue(1)?.getUint16() ?? 0;
   const max = result.getChildValue(2)?.getUint16() ?? 100;
-  return { result: resultCode, value, max };
+  return Promise.resolve({ result: resultCode, value, max });
 }
 
-async function setBrightness(proxy: DBusProxy, device: string, value: number): Promise<boolean> {
+function setBrightness(
+  proxy: DBusProxy,
+  device: string,
+  value: number,
+): Promise<boolean> {
   try {
     proxy.callSyncWithMixed("SetControl", device, 16, value);
-    return true;
+    return Promise.resolve(true);
   } catch {
-    return false;
+    return Promise.resolve(false);
   }
 }
 
@@ -186,7 +193,10 @@ class BrightnessControlWindow {
 
       this.#monitors = [];
       for (const monitor of allMonitors) {
-        const { result, max } = await getBrightness(this.#proxy, monitor.device);
+        const { result, max } = await getBrightness(
+          this.#proxy,
+          monitor.device,
+        );
         if (result >= 0 && max > 0 && max <= 1000) {
           this.#monitors.push(monitor);
         }
@@ -216,7 +226,8 @@ class BrightnessControlWindow {
 
   #selectPrev() {
     if (this.#monitors.length <= 1) return;
-    this.#currentIndex = (this.#currentIndex - 1 + this.#monitors.length) % this.#monitors.length;
+    this.#currentIndex = (this.#currentIndex - 1 + this.#monitors.length) %
+      this.#monitors.length;
     this.#updateUI();
   }
 

--- a/examples/brightness-control.ts
+++ b/examples/brightness-control.ts
@@ -1,0 +1,266 @@
+#!/usr/bin/env -S deno run --allow-ffi --allow-read
+
+import {
+  Adjustment,
+  Application,
+  ApplicationFlags,
+  ApplicationWindow,
+  Box,
+  Button,
+  Label,
+  Orientation,
+  Scale,
+} from "@sigmasd/gtk/gtk4";
+import { HeaderBar, ToolbarView } from "@sigmasd/gtk/adw";
+import { DBusProxy, BusType, DBusProxyFlags } from "@sigmasd/gtk/gio";
+import { EventLoop } from "@sigmasd/gtk/eventloop";
+
+const APP_ID = "com.example.BrightnessControl";
+const DDC_BUS = "ddccontrol.DDCControl";
+const DDC_PATH = "/ddccontrol/DDCControl";
+const DDC_IFACE = "ddccontrol.DDCControl";
+
+interface DDCMonitor {
+  device: string;
+  name: string;
+}
+
+async function getDBusProxy(): Promise<DBusProxy> {
+  const proxy = DBusProxy.newForBusSync(
+    BusType.SYSTEM,
+    DBusProxyFlags.NONE,
+    null,
+    DDC_BUS,
+    DDC_PATH,
+    DDC_IFACE,
+  );
+  if (!proxy) throw new Error("Failed to create D-Bus proxy");
+  return proxy;
+}
+
+async function getMonitors(proxy: DBusProxy): Promise<DDCMonitor[]> {
+  const result = proxy.callSyncWithStrings("GetMonitors");
+  if (!result) return [];
+
+  const devices = result.getChildValue(0);
+  if (!devices) return [];
+
+  const devicesList = devices.getStrv();
+  const monitors: DDCMonitor[] = [];
+
+  for (const device of devicesList) {
+    if (device.startsWith("dev:")) {
+      let name = `Monitor (${device})`;
+      try {
+        const openResult = proxy.callSyncWithStrings("OpenMonitor", device);
+        if (openResult && openResult.getChildrenCount() >= 1) {
+          const pnpid = openResult.getChildValue(0)?.getString();
+          if (pnpid && pnpid.trim()) {
+            name = pnpid.trim();
+            const caps = openResult.getChildValue(1)?.getString() || "";
+            const modelMatch = caps.match(/model\(([^)]+)\)/);
+            if (modelMatch) {
+              name = modelMatch[1];
+            }
+          }
+        }
+      } catch {
+        // OpenMonitor failed, use default name
+      }
+
+      monitors.push({ device, name });
+    }
+  }
+
+  return monitors;
+}
+
+async function getBrightness(proxy: DBusProxy, device: string): Promise<{ result: number; value: number; max: number }> {
+  const result = proxy.callSyncWithMixed("GetControl", device, 16);
+  if (!result) return { result: -1, value: 0, max: 100 };
+
+  const resultCode = result.getChildValue(0)?.getInt32() ?? -1;
+  const value = result.getChildValue(1)?.getUint16() ?? 0;
+  const max = result.getChildValue(2)?.getUint16() ?? 100;
+  return { result: resultCode, value, max };
+}
+
+async function setBrightness(proxy: DBusProxy, device: string, value: number): Promise<boolean> {
+  try {
+    proxy.callSyncWithMixed("SetControl", device, 16, value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+class BrightnessControlWindow {
+  #win: ApplicationWindow;
+  #monitors: DDCMonitor[] = [];
+  #currentIndex = 0;
+  #brightnessLabel!: Label;
+  #adjustment!: Adjustment;
+  #deviceLabel!: Label;
+  #statusLabel!: Label;
+  #navBox!: Box;
+  #slider!: Scale;
+  #mainBox!: Box;
+  #proxy!: DBusProxy;
+
+  constructor(app: Application) {
+    this.#win = new ApplicationWindow(app);
+    this.#win.setTitle("Brightness Control");
+    this.#win.setDefaultSize(450, 200);
+    this.#win.setResizable(false);
+
+    this.#buildUI();
+    this.#loadMonitors();
+  }
+
+  #buildUI() {
+    this.#win.setTitlebar(new HeaderBar());
+
+    this.#mainBox = new Box(Orientation.VERTICAL, 16);
+    this.#mainBox.setMarginTop(24);
+    this.#mainBox.setMarginBottom(24);
+    this.#mainBox.setMarginStart(24);
+    this.#mainBox.setMarginEnd(24);
+    this.#mainBox.setVisible(false);
+
+    this.#deviceLabel = new Label("Detecting displays...");
+    this.#deviceLabel.setXalign(0);
+    this.#mainBox.append(this.#deviceLabel);
+
+    this.#statusLabel = new Label("");
+    this.#statusLabel.setXalign(0);
+    this.#statusLabel.setWrap(true);
+    this.#mainBox.append(this.#statusLabel);
+
+    this.#adjustment = new Adjustment(0, 0, 100, 1, 10, 0);
+    this.#slider = new Scale(Orientation.HORIZONTAL, this.#adjustment);
+    this.#slider.setDigits(0);
+    this.#slider.setDrawValue(false);
+    this.#slider.setHexpand(true);
+    this.#slider.onValueChanged(() => {
+      if (this.#monitors.length === 0) return;
+      this.#onBrightnessChanged();
+    });
+
+    const sliderBox = new Box(Orientation.HORIZONTAL, 12);
+    sliderBox.setHexpand(true);
+    sliderBox.append(new Label("☀️"));
+    sliderBox.append(this.#slider);
+    sliderBox.append(new Label("🌞"));
+    this.#mainBox.append(sliderBox);
+
+    const percentBox = new Box(Orientation.HORIZONTAL, 8);
+    percentBox.setHexpand(true);
+    percentBox.append(new Label("Brightness:"));
+    this.#brightnessLabel = new Label("--%");
+    percentBox.append(this.#brightnessLabel);
+    this.#mainBox.append(percentBox);
+
+    this.#navBox = new Box(Orientation.HORIZONTAL, 8);
+    this.#navBox.setHexpand(true);
+    this.#navBox.setVisible(false);
+
+    const prevBtn = new Button("< Prev");
+    prevBtn.onClick(() => this.#selectPrev());
+    this.#navBox.append(prevBtn);
+
+    const nextBtn = new Button("Next >");
+    nextBtn.onClick(() => this.#selectNext());
+    this.#navBox.append(nextBtn);
+
+    this.#mainBox.append(this.#navBox);
+
+    const toolbarView = new ToolbarView();
+    toolbarView.setContent(this.#mainBox);
+    this.#win.setChild(toolbarView);
+  }
+
+  async #loadMonitors() {
+    try {
+      this.#proxy = await getDBusProxy();
+      const allMonitors = await getMonitors(this.#proxy);
+
+      this.#monitors = [];
+      for (const monitor of allMonitors) {
+        const { result, max } = await getBrightness(this.#proxy, monitor.device);
+        if (result >= 0 && max > 0 && max <= 1000) {
+          this.#monitors.push(monitor);
+        }
+      }
+    } catch {
+      // Failed to load monitors
+    }
+
+    if (this.#monitors.length === 0) {
+      this.#deviceLabel.setText("No displays found.");
+      this.#statusLabel.setText(
+        "Make sure ddccontrol service is running:\nsudo systemctl restart ddccontrol",
+      );
+      this.#mainBox.setVisible(true);
+      return;
+    }
+
+    this.#mainBox.setVisible(true);
+    await this.#updateUI();
+  }
+
+  #selectNext() {
+    if (this.#monitors.length <= 1) return;
+    this.#currentIndex = (this.#currentIndex + 1) % this.#monitors.length;
+    this.#updateUI();
+  }
+
+  #selectPrev() {
+    if (this.#monitors.length <= 1) return;
+    this.#currentIndex = (this.#currentIndex - 1 + this.#monitors.length) % this.#monitors.length;
+    this.#updateUI();
+  }
+
+  async #updateUI() {
+    const monitor = this.#monitors[this.#currentIndex];
+    this.#deviceLabel.setText(`Display: ${monitor.name}`);
+    this.#navBox.setVisible(this.#monitors.length > 1);
+
+    const { value, max } = await getBrightness(this.#proxy, monitor.device);
+    const percent = max > 0 ? Math.round((value / max) * 100) : 0;
+
+    this.#adjustment.setValue(percent);
+    this.#brightnessLabel.setText(`${percent}%`);
+  }
+
+  async #onBrightnessChanged() {
+    const monitor = this.#monitors[this.#currentIndex];
+    const percent = Math.round(this.#adjustment.getValue());
+
+    if (await setBrightness(this.#proxy, monitor.device, percent)) {
+      this.#brightnessLabel.setText(`${percent}%`);
+    }
+  }
+
+  present() {
+    this.#win.setVisible(true);
+  }
+}
+
+class BrightnessControlApp {
+  #app = new Application(APP_ID, ApplicationFlags.NONE);
+
+  constructor() {
+    this.#app.onActivate(() => {
+      const win = new BrightnessControlWindow(this.#app);
+      win.present();
+    });
+  }
+
+  run() {
+    new EventLoop().start(this.#app);
+  }
+}
+
+if (import.meta.main) {
+  new BrightnessControlApp().run();
+}

--- a/examples/brightness-control.ts
+++ b/examples/brightness-control.ts
@@ -114,11 +114,15 @@ class BrightnessControlWindow {
   #mainBox!: Box;
   #proxy!: DBusProxy;
 
-  constructor(app: Application) {
+  constructor(app: Application, onClose: () => void) {
     this.#win = new ApplicationWindow(app);
     this.#win.setTitle("Brightness Control");
     this.#win.setDefaultSize(450, 200);
     this.#win.setResizable(false);
+    this.#win.onCloseRequest(() => {
+      onClose();
+      return true;
+    });
 
     this.#buildUI();
     this.#loadMonitors();
@@ -259,16 +263,19 @@ class BrightnessControlWindow {
 
 class BrightnessControlApp {
   #app = new Application(APP_ID, ApplicationFlags.NONE);
+  #eventLoop = new EventLoop();
 
   constructor() {
     this.#app.onActivate(() => {
-      const win = new BrightnessControlWindow(this.#app);
+      const win = new BrightnessControlWindow(this.#app, () => {
+        this.#eventLoop.stop();
+      });
       win.present();
     });
   }
 
   run() {
-    new EventLoop().start(this.#app);
+    this.#eventLoop.start(this.#app);
   }
 }
 

--- a/examples/test-dbus.ts
+++ b/examples/test-dbus.ts
@@ -1,12 +1,12 @@
 #!/usr/bin/env -S deno run --allow-ffi
 
-import { DBusProxy, BusType, DBusProxyFlags } from "@sigmasd/gtk/gio";
+import { BusType, DBusProxy, DBusProxyFlags } from "@sigmasd/gtk/gio";
 
 const DDC_BUS = "ddccontrol.DDCControl";
 const DDC_PATH = "/ddccontrol/DDCControl";
 const DDC_IFACE = "ddccontrol.DDCControl";
 
-async function main() {
+function main() {
   console.log("Creating D-Bus proxy...");
   const proxy = DBusProxy.newForBusSync(
     BusType.SYSTEM,
@@ -16,7 +16,7 @@ async function main() {
     DDC_PATH,
     DDC_IFACE,
   );
-  
+
   if (!proxy) {
     console.error("Failed to create proxy");
     return;
@@ -30,10 +30,10 @@ async function main() {
     console.error("GetMonitors returned null");
     return;
   }
-  
+
   console.log("Result type:", result.getTypeString());
   console.log("Children count:", result.getChildrenCount());
-  
+
   for (let i = 0; i < result.getChildrenCount(); i++) {
     const child = result.getChildValue(i);
     if (child) {
@@ -45,20 +45,26 @@ async function main() {
   }
 
   console.log("\nCalling GetControl on dev:/dev/i2c-4 with mixed types...");
-  const brightness = proxy.callSyncWithMixed("GetControl", "dev:/dev/i2c-4", 16);
+  const brightness = proxy.callSyncWithMixed(
+    "GetControl",
+    "dev:/dev/i2c-4",
+    16,
+  );
   console.log("GetControl completed");
   if (!brightness) {
     console.error("GetControl returned null");
     return;
   }
-  
+
   console.log("Brightness result type:", brightness.getTypeString());
   console.log("Brightness children:", brightness.getChildrenCount());
-  
+
   for (let i = 0; i < brightness.getChildrenCount(); i++) {
     const child = brightness.getChildValue(i);
     if (child) {
-      console.log(`  Child ${i}: type=${child.getTypeString()}, value=${child.getInt32()}`);
+      console.log(
+        `  Child ${i}: type=${child.getTypeString()}, value=${child.getInt32()}`,
+      );
     }
   }
 
@@ -70,16 +76,31 @@ async function main() {
 
   // Test SetControl with correct params (device, control, value)
   console.log("\nTesting SetControl to 50...");
-  const setResult = proxy.callSyncWithMixed("SetControl", "dev:/dev/i2c-4", 16, 50);
-  console.log("SetControl result:", setResult?.getTypeString(), setResult?.getChildrenCount());
-  
+  const setResult = proxy.callSyncWithMixed(
+    "SetControl",
+    "dev:/dev/i2c-4",
+    16,
+    50,
+  );
+  console.log(
+    "SetControl result:",
+    setResult?.getTypeString(),
+    setResult?.getChildrenCount(),
+  );
+
   // Read back
-  const brightness2 = proxy.callSyncWithMixed("GetControl", "dev:/dev/i2c-4", 16);
+  const brightness2 = proxy.callSyncWithMixed(
+    "GetControl",
+    "dev:/dev/i2c-4",
+    16,
+  );
   if (brightness2) {
     const resultCode = brightness2.getChildValue(0)?.getInt32();
     const value2 = brightness2.getChildValue(1)?.getUint16();
     const max2 = brightness2.getChildValue(2)?.getUint16();
-    console.log(`After set: result=${resultCode}, Value: ${value2}, Max: ${max2}`);
+    console.log(
+      `After set: result=${resultCode}, Value: ${value2}, Max: ${max2}`,
+    );
   }
 }
 

--- a/examples/test-dbus.ts
+++ b/examples/test-dbus.ts
@@ -1,0 +1,86 @@
+#!/usr/bin/env -S deno run --allow-ffi
+
+import { DBusProxy, BusType, DBusProxyFlags } from "@sigmasd/gtk/gio";
+
+const DDC_BUS = "ddccontrol.DDCControl";
+const DDC_PATH = "/ddccontrol/DDCControl";
+const DDC_IFACE = "ddccontrol.DDCControl";
+
+async function main() {
+  console.log("Creating D-Bus proxy...");
+  const proxy = DBusProxy.newForBusSync(
+    BusType.SYSTEM,
+    DBusProxyFlags.NONE,
+    null,
+    DDC_BUS,
+    DDC_PATH,
+    DDC_IFACE,
+  );
+  
+  if (!proxy) {
+    console.error("Failed to create proxy");
+    return;
+  }
+  console.log("Proxy created OK");
+
+  console.log("\nCalling GetMonitors with sync...");
+  const result = proxy.callSyncWithStrings("GetMonitors");
+  console.log("Sync call completed");
+  if (!result) {
+    console.error("GetMonitors returned null");
+    return;
+  }
+  
+  console.log("Result type:", result.getTypeString());
+  console.log("Children count:", result.getChildrenCount());
+  
+  for (let i = 0; i < result.getChildrenCount(); i++) {
+    const child = result.getChildValue(i);
+    if (child) {
+      console.log(`Child ${i}: type=${child.getTypeString()}`);
+      if (child.getTypeString() === "as") {
+        console.log(`  strv:`, child.getStrv());
+      }
+    }
+  }
+
+  console.log("\nCalling GetControl on dev:/dev/i2c-4 with mixed types...");
+  const brightness = proxy.callSyncWithMixed("GetControl", "dev:/dev/i2c-4", 16);
+  console.log("GetControl completed");
+  if (!brightness) {
+    console.error("GetControl returned null");
+    return;
+  }
+  
+  console.log("Brightness result type:", brightness.getTypeString());
+  console.log("Brightness children:", brightness.getChildrenCount());
+  
+  for (let i = 0; i < brightness.getChildrenCount(); i++) {
+    const child = brightness.getChildValue(i);
+    if (child) {
+      console.log(`  Child ${i}: type=${child.getTypeString()}, value=${child.getInt32()}`);
+    }
+  }
+
+  // Extract value and max
+  const resultVal = brightness.getChildValue(0)?.getInt32();
+  const value = brightness.getChildValue(1)?.getUint16();
+  const max = brightness.getChildValue(2)?.getUint16();
+  console.log(`Result: ${resultVal}, Value: ${value}, Max: ${max}`);
+
+  // Test SetControl with correct params (device, control, value)
+  console.log("\nTesting SetControl to 50...");
+  const setResult = proxy.callSyncWithMixed("SetControl", "dev:/dev/i2c-4", 16, 50);
+  console.log("SetControl result:", setResult?.getTypeString(), setResult?.getChildrenCount());
+  
+  // Read back
+  const brightness2 = proxy.callSyncWithMixed("GetControl", "dev:/dev/i2c-4", 16);
+  if (brightness2) {
+    const resultCode = brightness2.getChildValue(0)?.getInt32();
+    const value2 = brightness2.getChildValue(1)?.getUint16();
+    const max2 = brightness2.getChildValue(2)?.getUint16();
+    console.log(`After set: result=${resultCode}, Value: ${value2}, Max: ${max2}`);
+  }
+}
+
+main();

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "@sigmasd/gtk",
       "dependencies": {
-        "@sigma/deno-compat": "npm:@jsr/sigma__deno-compat@^0.22.0"
+        "@sigma/deno-compat": "npm:@jsr/sigma__deno-compat@^0.23.0"
       },
       "peerDependencies": {
         "koffi": "^2.15.1"
@@ -14,9 +14,9 @@
     },
     "node_modules/@sigma/deno-compat": {
       "name": "@jsr/sigma__deno-compat",
-      "version": "0.22.0",
-      "resolved": "https://npm.jsr.io/~/11/@jsr/sigma__deno-compat/0.22.0.tgz",
-      "integrity": "sha512-mplzn1IjsnhANpofMquCMKXadX5yt00pN1EaLqasAqB3CtLYmdjGGBH0mKhs8u0INba8sxTRDyfvcL1eKw89vw=="
+      "version": "0.23.0",
+      "resolved": "https://npm.jsr.io/~/11/@jsr/sigma__deno-compat/0.23.0.tgz",
+      "integrity": "sha512-xBjRuR/lzG81UeaoiD0dWTJTdKHBI57RTwNtCSvwhQGJ95FP/dpbJrn0A4jHJd7xKF6CQD3aETf2Z4Vqls2Dng=="
     },
     "node_modules/koffi": {
       "version": "2.15.1",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "./cairo": "./src/high/cairo.ts"
   },
   "dependencies": {
-    "@sigma/deno-compat": "npm:@jsr/sigma__deno-compat@^0.22.0"
+    "@sigma/deno-compat": "npm:@jsr/sigma__deno-compat@^0.23.0"
   },
   "peerDependencies": {
     "koffi": "^2.15.1"

--- a/src/high/gio.ts
+++ b/src/high/gio.ts
@@ -497,17 +497,17 @@ export class DBusProxy extends GObject {
     ...args: (string | number)[]
   ): Variant | null {
     const variantPtrs = new BigUint64Array(args.length);
-    
+
     for (let i = 0; i < args.length; i++) {
       const arg = args[i];
       let variant: Deno.PointerValue;
-      
+
       if (typeof arg === "string") {
         variant = glib.symbols.g_variant_new_string(cstr(arg))!;
       } else {
         variant = glib.symbols.g_variant_new_uint32(arg)!;
       }
-      
+
       variantPtrs[i] = BigInt(Deno.UnsafePointer.value(variant));
     }
 
@@ -552,7 +552,11 @@ export class DBusProxy extends GObject {
         parameters: ["pointer", "pointer", "pointer"],
         result: "void",
       } as const,
-      (_source: Deno.PointerValue, result: Deno.PointerValue, _userData: Deno.PointerValue) => {
+      (
+        _source: Deno.PointerValue,
+        result: Deno.PointerValue,
+        _userData: Deno.PointerValue,
+      ) => {
         const finish = gio.symbols.g_dbus_proxy_call_finish;
         if (finish) {
           const variant = finish(this.ptr, result, null);

--- a/src/high/gio.ts
+++ b/src/high/gio.ts
@@ -471,6 +471,55 @@ export class DBusProxy extends GObject {
     return value;
   }
 
+  // Call sync with string args, returns Variant result
+  callSyncWithStrings(
+    methodName: string,
+    ...args: string[]
+  ): Variant | null {
+    const variantPtrs = new BigUint64Array(args.length);
+    for (let i = 0; i < args.length; i++) {
+      const strVariant = glib.symbols.g_variant_new_string(cstr(args[i]));
+      variantPtrs[i] = BigInt(Deno.UnsafePointer.value(strVariant!));
+    }
+
+    const tupleVariant = glib.symbols.g_variant_new_tuple(
+      Deno.UnsafePointer.of(variantPtrs),
+      BigInt(args.length),
+    );
+
+    const result = this.callSync(methodName, tupleVariant);
+    return result ? new Variant(result) : null;
+  }
+
+  // Call sync with mixed type args (strings and numbers)
+  callSyncWithMixed(
+    methodName: string,
+    ...args: (string | number)[]
+  ): Variant | null {
+    const variantPtrs = new BigUint64Array(args.length);
+    
+    for (let i = 0; i < args.length; i++) {
+      const arg = args[i];
+      let variant: Deno.PointerValue;
+      
+      if (typeof arg === "string") {
+        variant = glib.symbols.g_variant_new_string(cstr(arg))!;
+      } else {
+        variant = glib.symbols.g_variant_new_uint32(arg)!;
+      }
+      
+      variantPtrs[i] = BigInt(Deno.UnsafePointer.value(variant));
+    }
+
+    const tupleVariant = glib.symbols.g_variant_new_tuple(
+      Deno.UnsafePointer.of(variantPtrs),
+      BigInt(args.length),
+    );
+
+    const result = this.callSync(methodName, tupleVariant);
+    return result ? new Variant(result) : null;
+  }
+
   // Helper to call methods with uint32 parameter
   callWithUint32(methodName: string, value: number): void {
     // Create a uint32 variant wrapped in a tuple for D-Bus call
@@ -485,13 +534,90 @@ export class DBusProxy extends GObject {
 
     this.callSync(methodName, tupleVariant);
   }
+
+  // Async call with callback
+  callAsync(
+    methodName: string,
+    parameters: Deno.PointerValue | null,
+    callback: (result: Deno.PointerValue | null) => void,
+    flags: number = DBusCallFlags.NONE,
+    timeoutMsec: number = -1,
+  ): void {
+    if (!gio.symbols.g_dbus_proxy_call) {
+      throw new Error("D-Bus async is not available");
+    }
+
+    const cb = new Deno.UnsafeCallback(
+      {
+        parameters: ["pointer", "pointer", "pointer"],
+        result: "void",
+      } as const,
+      (_source: Deno.PointerValue, result: Deno.PointerValue, _userData: Deno.PointerValue) => {
+        const finish = gio.symbols.g_dbus_proxy_call_finish;
+        if (finish) {
+          const variant = finish(this.ptr, result, null);
+          callback(variant);
+        } else {
+          callback(null);
+        }
+      },
+    );
+
+    gio.symbols.g_dbus_proxy_call(
+      this.ptr,
+      cstr(methodName),
+      parameters,
+      flags,
+      timeoutMsec,
+      null,
+      cb.pointer,
+      null,
+    );
+  }
+
+  // Call with string args, returns Variant result via async
+  callAsyncWithStrings(
+    methodName: string,
+    ...args: string[]
+  ): Promise<Variant | null> {
+    // Build string array variant
+    const strVariants = new Array(args.length);
+    for (let i = 0; i < args.length; i++) {
+      strVariants[i] = glib.symbols.g_variant_new_string(cstr(args[i]));
+    }
+
+    const variantPtrs = new BigUint64Array(args.length);
+    for (let i = 0; i < args.length; i++) {
+      variantPtrs[i] = BigInt(Deno.UnsafePointer.value(strVariants[i]!));
+    }
+
+    const tupleVariant = glib.symbols.g_variant_new_tuple(
+      Deno.UnsafePointer.of(variantPtrs),
+      BigInt(args.length),
+    );
+
+    return new Promise((resolve, reject) => {
+      const timeoutId = setTimeout(() => {
+        reject(new Error("D-Bus call timeout"));
+      }, 5000);
+
+      this.callAsync(methodName, tupleVariant, (result) => {
+        clearTimeout(timeoutId);
+        if (!result) {
+          resolve(null);
+          return;
+        }
+        resolve(new Variant(result));
+      });
+    });
+  }
 }
 
 // Helper class for creating GVariant values
 export class Variant {
   ptr: Deno.PointerValue;
 
-  private constructor(ptr: Deno.PointerValue) {
+  constructor(ptr: Deno.PointerValue) {
     this.ptr = ptr;
   }
 
@@ -533,6 +659,39 @@ export class Variant {
 
   getInt32(): number {
     return glib.symbols.g_variant_get_int32(this.ptr);
+  }
+
+  getUint16(): number {
+    return glib.symbols.g_variant_get_uint16(this.ptr);
+  }
+
+  getTypeString(): string {
+    const ptr = glib.symbols.g_variant_get_type_string(this.ptr);
+    return ptr ? readCStr(ptr) : "";
+  }
+
+  getChildrenCount(): number {
+    const count = glib.symbols.g_variant_n_children(this.ptr);
+    return Number(count);
+  }
+
+  isOfType(typeString: string): boolean {
+    return this.getTypeString() === typeString;
+  }
+
+  getStrv(): string[] {
+    if (!this.isOfType("as")) return [];
+    const count = this.getChildrenCount();
+    const arr: string[] = [];
+    for (let i = 0; i < count; i++) {
+      const child = this.getChildValue(i);
+      arr.push(child?.getString() || "");
+    }
+    return arr;
+  }
+
+  isNull(): boolean {
+    return this.ptr === null;
   }
 
   unref(): void {

--- a/src/high/glib.ts
+++ b/src/high/glib.ts
@@ -1,4 +1,5 @@
 import { glib } from "../low/glib.ts";
+export { glib };
 
 // ============================================================================
 // GLib Enums and Constants

--- a/src/high/glib.ts
+++ b/src/high/glib.ts
@@ -1,5 +1,4 @@
 import { glib } from "../low/glib.ts";
-export { glib };
 
 // ============================================================================
 // GLib Enums and Constants

--- a/src/high/gtk4.ts
+++ b/src/high/gtk4.ts
@@ -585,6 +585,22 @@ export class Separator extends Widget {
 
 // GTK Adjustment
 export class Adjustment extends GObject {
+  constructor(valueOrPtr?: number | Deno.PointerValue, lower?: number, upper?: number, stepIncrement?: number, pageIncrement?: number, pageSize?: number) {
+    let ptr: Deno.PointerValue;
+    if (typeof valueOrPtr === "number") {
+      ptr = gtk4.symbols.gtk_adjustment_new(valueOrPtr, lower!, upper!, stepIncrement!, pageIncrement!, pageSize!);
+    } else if (valueOrPtr !== undefined) {
+      ptr = valueOrPtr;
+    } else {
+      ptr = gtk4.symbols.gtk_adjustment_new(0, 0, 100, 1, 10, 0);
+    }
+    super(ptr);
+  }
+
+  getValue(): number {
+    return gtk4.symbols.gtk_adjustment_get_value(this.ptr);
+  }
+
   getUpper(): number {
     return gtk4.symbols.gtk_adjustment_get_upper(this.ptr);
   }
@@ -595,6 +611,42 @@ export class Adjustment extends GObject {
 
   setValue(value: number): void {
     gtk4.symbols.gtk_adjustment_set_value(this.ptr, value);
+  }
+}
+
+// GTK Scale
+export class Scale extends Widget {
+  #adjustment: Adjustment;
+
+  constructor(orientation: number, adjustment?: Adjustment) {
+    const adj = adjustment ?? new Adjustment(0, 0, 100, 1, 10, 0);
+    const ptr = gtk4.symbols.gtk_scale_new(orientation, adj.ptr);
+    super(ptr);
+    this.#adjustment = adj;
+  }
+
+  setDigits(digits: number): void {
+    gtk4.symbols.gtk_scale_set_digits(this.ptr, digits);
+  }
+
+  setDrawValue(drawValue: boolean): void {
+    gtk4.symbols.gtk_scale_set_draw_value(this.ptr, drawValue);
+  }
+
+  getValue(): number {
+    return gtk4.symbols.gtk_range_get_value(this.ptr);
+  }
+
+  setValue(value: number): void {
+    gtk4.symbols.gtk_range_set_value(this.ptr, value);
+  }
+
+  getAdjustment(): Adjustment {
+    return this.#adjustment;
+  }
+
+  onValueChanged(callback: () => void): number {
+    return this.connect("value-changed", callback);
   }
 }
 

--- a/src/high/gtk4.ts
+++ b/src/high/gtk4.ts
@@ -585,25 +585,11 @@ export class Separator extends Widget {
 
 // GTK Adjustment
 export class Adjustment extends GObject {
-  constructor(
-    valueOrPtr?: number | Deno.PointerValue,
-    lower?: number,
-    upper?: number,
-    stepIncrement?: number,
-    pageIncrement?: number,
-    pageSize?: number,
-  ) {
+  constructor(valueOrPtr?: number | Deno.PointerValue | null, lower?: number, upper?: number, stepIncrement?: number, pageIncrement?: number, pageSize?: number) {
     let ptr: Deno.PointerValue;
     if (typeof valueOrPtr === "number") {
-      ptr = gtk4.symbols.gtk_adjustment_new(
-        valueOrPtr,
-        lower!,
-        upper!,
-        stepIncrement!,
-        pageIncrement!,
-        pageSize!,
-      );
-    } else if (valueOrPtr !== undefined) {
+      ptr = gtk4.symbols.gtk_adjustment_new(valueOrPtr, lower!, upper!, stepIncrement!, pageIncrement!, pageSize!);
+    } else if (valueOrPtr != null) {
       ptr = valueOrPtr;
     } else {
       ptr = gtk4.symbols.gtk_adjustment_new(0, 0, 100, 1, 10, 0);
@@ -615,6 +601,10 @@ export class Adjustment extends GObject {
     return gtk4.symbols.gtk_adjustment_get_value(this.ptr);
   }
 
+  setValue(value: number): void {
+    gtk4.symbols.gtk_adjustment_set_value(this.ptr, value);
+  }
+
   getUpper(): number {
     return gtk4.symbols.gtk_adjustment_get_upper(this.ptr);
   }
@@ -622,45 +612,35 @@ export class Adjustment extends GObject {
   getPageSize(): number {
     return gtk4.symbols.gtk_adjustment_get_page_size(this.ptr);
   }
-
-  setValue(value: number): void {
-    gtk4.symbols.gtk_adjustment_set_value(this.ptr, value);
-  }
 }
 
 // GTK Scale
 export class Scale extends Widget {
   #adjustment: Adjustment;
 
-  constructor(orientation: number, adjustment?: Adjustment) {
-    const adj = adjustment ?? new Adjustment(0, 0, 100, 1, 10, 0);
-    const ptr = gtk4.symbols.gtk_scale_new(orientation, adj.ptr);
+  constructor(orientation: number, adjustment: Adjustment) {
+    const ptr = gtk4.symbols.gtk_scale_new(orientation, null);
     super(ptr);
-    this.#adjustment = adj;
-  }
-
-  setDigits(digits: number): void {
-    gtk4.symbols.gtk_scale_set_digits(this.ptr, digits);
+    this.#adjustment = adjustment;
   }
 
   setDrawValue(drawValue: boolean): void {
     gtk4.symbols.gtk_scale_set_draw_value(this.ptr, drawValue);
   }
 
-  getValue(): number {
-    return gtk4.symbols.gtk_range_get_value(this.ptr);
+  setDigits(digits: number): void {
+    gtk4.symbols.gtk_scale_set_digits(this.ptr, digits);
   }
 
-  setValue(value: number): void {
-    gtk4.symbols.gtk_range_set_value(this.ptr, value);
-  }
-
-  getAdjustment(): Adjustment {
-    return this.#adjustment;
-  }
-
-  onValueChanged(callback: () => void): number {
-    return this.connect("value-changed", callback);
+  onValueChanged(callback: () => void): void {
+    const cb = new Deno.UnsafeCallback(
+      {
+        parameters: ["pointer", "pointer"],
+        result: "void",
+      } as const,
+      () => callback(),
+    );
+    gtk4.symbols.g_signal_connect(this.ptr, cstr("value_changed"), cb.pointer, null);
   }
 }
 

--- a/src/high/gtk4.ts
+++ b/src/high/gtk4.ts
@@ -649,16 +649,22 @@ export class Scale extends Widget {
   onValueChanged(callback: () => void): void {
     const cb = new Deno.UnsafeCallback(
       {
-        parameters: ["pointer", "pointer"],
+        parameters: ["pointer", "pointer", "pointer"],
         result: "void",
       } as const,
-      () => callback(),
+      (
+        _self: Deno.PointerValue,
+        _param: Deno.PointerValue,
+        _data: Deno.PointerValue,
+      ) => callback(),
     );
-    gtk4.symbols.g_signal_connect(
+    gobject.symbols.g_signal_connect_data(
       this.ptr,
       cstr("value_changed"),
       cb.pointer,
       null,
+      null,
+      0,
     );
   }
 }

--- a/src/high/gtk4.ts
+++ b/src/high/gtk4.ts
@@ -585,10 +585,24 @@ export class Separator extends Widget {
 
 // GTK Adjustment
 export class Adjustment extends GObject {
-  constructor(valueOrPtr?: number | Deno.PointerValue | null, lower?: number, upper?: number, stepIncrement?: number, pageIncrement?: number, pageSize?: number) {
+  constructor(
+    valueOrPtr?: number | Deno.PointerValue | null,
+    lower?: number,
+    upper?: number,
+    stepIncrement?: number,
+    pageIncrement?: number,
+    pageSize?: number,
+  ) {
     let ptr: Deno.PointerValue;
     if (typeof valueOrPtr === "number") {
-      ptr = gtk4.symbols.gtk_adjustment_new(valueOrPtr, lower!, upper!, stepIncrement!, pageIncrement!, pageSize!);
+      ptr = gtk4.symbols.gtk_adjustment_new(
+        valueOrPtr,
+        lower!,
+        upper!,
+        stepIncrement!,
+        pageIncrement!,
+        pageSize!,
+      );
     } else if (valueOrPtr != null) {
       ptr = valueOrPtr;
     } else {
@@ -640,7 +654,12 @@ export class Scale extends Widget {
       } as const,
       () => callback(),
     );
-    gtk4.symbols.g_signal_connect(this.ptr, cstr("value_changed"), cb.pointer, null);
+    gtk4.symbols.g_signal_connect(
+      this.ptr,
+      cstr("value_changed"),
+      cb.pointer,
+      null,
+    );
   }
 }
 

--- a/src/high/gtk4.ts
+++ b/src/high/gtk4.ts
@@ -585,10 +585,24 @@ export class Separator extends Widget {
 
 // GTK Adjustment
 export class Adjustment extends GObject {
-  constructor(valueOrPtr?: number | Deno.PointerValue, lower?: number, upper?: number, stepIncrement?: number, pageIncrement?: number, pageSize?: number) {
+  constructor(
+    valueOrPtr?: number | Deno.PointerValue,
+    lower?: number,
+    upper?: number,
+    stepIncrement?: number,
+    pageIncrement?: number,
+    pageSize?: number,
+  ) {
     let ptr: Deno.PointerValue;
     if (typeof valueOrPtr === "number") {
-      ptr = gtk4.symbols.gtk_adjustment_new(valueOrPtr, lower!, upper!, stepIncrement!, pageIncrement!, pageSize!);
+      ptr = gtk4.symbols.gtk_adjustment_new(
+        valueOrPtr,
+        lower!,
+        upper!,
+        stepIncrement!,
+        pageIncrement!,
+        pageSize!,
+      );
     } else if (valueOrPtr !== undefined) {
       ptr = valueOrPtr;
     } else {

--- a/src/high/gtk4.ts
+++ b/src/high/gtk4.ts
@@ -636,6 +636,7 @@ export class Scale extends Widget {
     const ptr = gtk4.symbols.gtk_scale_new(orientation, null);
     super(ptr);
     this.#adjustment = adjustment;
+    gtk4.symbols.gtk_range_set_adjustment(this.ptr, adjustment.ptr);
   }
 
   setDrawValue(drawValue: boolean): void {

--- a/src/low/glib.ts
+++ b/src/low/glib.ts
@@ -2,7 +2,51 @@
 import "@sigma/deno-compat";
 import { LIB_PATHS } from "./paths/mod.ts";
 
-export const glib: ReturnType<typeof Deno.dlopen> = Deno.dlopen(LIB_PATHS.glib, {
+interface GlibSymbols {
+  g_main_loop_new: (context: Deno.PointerValue, isRunning: boolean) => Deno.PointerValue;
+  g_main_loop_run: (loop: Deno.PointerValue) => void;
+  g_main_loop_quit: (loop: Deno.PointerValue) => void;
+  g_main_context_default: () => Deno.PointerValue;
+  g_main_context_pending: (context: Deno.PointerValue) => boolean;
+  g_main_context_iteration: (context: Deno.PointerValue, mayBlock: boolean) => boolean;
+  g_timeout_add: (interval: number, callback: Deno.PointerValue, data: Deno.PointerValue) => number;
+  g_timeout_add_seconds: (interval: number, callback: Deno.PointerValue, data: Deno.PointerValue) => number;
+  g_idle_add: (callback: Deno.PointerValue, data: Deno.PointerValue) => number;
+  g_source_remove: (tag: number) => boolean;
+  g_free: (mem: Deno.PointerValue) => void;
+  g_free_ptr: Deno.PointerValue;
+  g_strdup: (str: BufferSource) => Deno.PointerValue;
+  g_malloc0: (n: bigint) => Deno.PointerValue;
+  g_unix_signal_add?: ((signum: number, callback: Deno.PointerValue, data: Deno.PointerValue) => number) | null;
+  g_bytes_new: (data: BufferSource, len: bigint) => Deno.PointerValue;
+  g_bytes_get_data: (bytes: Deno.PointerValue, len: Deno.PointerValue) => Deno.PointerValue;
+  g_bytes_get_size: (bytes: Deno.PointerValue) => bigint;
+  g_bytes_unref: (bytes: Deno.PointerValue) => void;
+  g_variant_new_string: (str: BufferSource) => Deno.PointerValue;
+  g_variant_new_uint32: (value: number) => Deno.PointerValue;
+  g_variant_new_tuple: (children: Deno.PointerValue, nChildren: bigint) => Deno.PointerValue;
+  g_variant_get_child_value: (variant: Deno.PointerValue, index: bigint) => Deno.PointerValue;
+  g_variant_get_string: (variant: Deno.PointerValue, len: Deno.PointerValue) => Deno.PointerValue;
+  g_variant_get_uint32: (variant: Deno.PointerValue) => number;
+  g_variant_get_int32: (variant: Deno.PointerValue) => number;
+  g_variant_get_uint16: (variant: Deno.PointerValue) => number;
+  g_variant_get_type_string: (variant: Deno.PointerValue) => Deno.PointerValue;
+  g_variant_n_children: (variant: Deno.PointerValue) => bigint;
+  g_variant_type_hash: (type: Deno.PointerValue) => Deno.PointerValue;
+  g_variant_is_of_type: (variant: Deno.PointerValue, type: Deno.PointerValue) => boolean;
+  g_variant_unref: (variant: Deno.PointerValue) => void;
+  g_variant_ref: (variant: Deno.PointerValue) => Deno.PointerValue;
+  g_variant_ref_sink: (variant: Deno.PointerValue) => Deno.PointerValue;
+  g_set_prgname: (name: BufferSource) => void;
+  g_set_application_name: (name: BufferSource) => void;
+}
+
+interface GlibLib {
+  symbols: GlibSymbols;
+  close: () => void;
+}
+
+export const glib: GlibLib = Deno.dlopen(LIB_PATHS.glib, {
   g_main_loop_new: { parameters: ["pointer", "bool"], result: "pointer" },
   g_main_loop_run: { parameters: ["pointer"], result: "void" },
   g_main_loop_quit: { parameters: ["pointer"], result: "void" },
@@ -34,7 +78,6 @@ export const glib: ReturnType<typeof Deno.dlopen> = Deno.dlopen(LIB_PATHS.glib, 
     result: "u32",
     optional: true,
   },
-  // GBytes
   g_bytes_new: {
     parameters: ["buffer", "usize"],
     result: "pointer",
@@ -51,7 +94,6 @@ export const glib: ReturnType<typeof Deno.dlopen> = Deno.dlopen(LIB_PATHS.glib, 
     parameters: ["pointer"],
     result: "void",
   },
-  // GVariant
   g_variant_new_string: {
     parameters: ["buffer"],
     result: "pointer",

--- a/src/low/glib.ts
+++ b/src/low/glib.ts
@@ -2,7 +2,7 @@
 import "@sigma/deno-compat";
 import { LIB_PATHS } from "./paths/mod.ts";
 
-export const glib = Deno.dlopen(LIB_PATHS.glib, {
+export const glib: ReturnType<typeof Deno.dlopen> = Deno.dlopen(LIB_PATHS.glib, {
   g_main_loop_new: { parameters: ["pointer", "bool"], result: "pointer" },
   g_main_loop_run: { parameters: ["pointer"], result: "void" },
   g_main_loop_quit: { parameters: ["pointer"], result: "void" },

--- a/src/low/glib.ts
+++ b/src/low/glib.ts
@@ -80,6 +80,26 @@ export const glib = Deno.dlopen(LIB_PATHS.glib, {
     parameters: ["pointer"],
     result: "i32",
   },
+  g_variant_get_uint16: {
+    parameters: ["pointer"],
+    result: "u16",
+  },
+  g_variant_get_type_string: {
+    parameters: ["pointer"],
+    result: "pointer",
+  },
+  g_variant_n_children: {
+    parameters: ["pointer"],
+    result: "usize",
+  },
+  g_variant_type_hash: {
+    parameters: ["pointer"],
+    result: "pointer",
+  },
+  g_variant_is_of_type: {
+    parameters: ["pointer", "pointer"],
+    result: "bool",
+  },
   g_variant_unref: {
     parameters: ["pointer"],
     result: "void",

--- a/src/low/glib.ts
+++ b/src/low/glib.ts
@@ -2,51 +2,7 @@
 import "@sigma/deno-compat";
 import { LIB_PATHS } from "./paths/mod.ts";
 
-interface GlibSymbols {
-  g_main_loop_new: (context: Deno.PointerValue, isRunning: boolean) => Deno.PointerValue;
-  g_main_loop_run: (loop: Deno.PointerValue) => void;
-  g_main_loop_quit: (loop: Deno.PointerValue) => void;
-  g_main_context_default: () => Deno.PointerValue;
-  g_main_context_pending: (context: Deno.PointerValue) => boolean;
-  g_main_context_iteration: (context: Deno.PointerValue, mayBlock: boolean) => boolean;
-  g_timeout_add: (interval: number, callback: Deno.PointerValue, data: Deno.PointerValue) => number;
-  g_timeout_add_seconds: (interval: number, callback: Deno.PointerValue, data: Deno.PointerValue) => number;
-  g_idle_add: (callback: Deno.PointerValue, data: Deno.PointerValue) => number;
-  g_source_remove: (tag: number) => boolean;
-  g_free: (mem: Deno.PointerValue) => void;
-  g_free_ptr: Deno.PointerValue;
-  g_strdup: (str: BufferSource) => Deno.PointerValue;
-  g_malloc0: (n: bigint) => Deno.PointerValue;
-  g_unix_signal_add?: ((signum: number, callback: Deno.PointerValue, data: Deno.PointerValue) => number) | null;
-  g_bytes_new: (data: BufferSource, len: bigint) => Deno.PointerValue;
-  g_bytes_get_data: (bytes: Deno.PointerValue, len: Deno.PointerValue) => Deno.PointerValue;
-  g_bytes_get_size: (bytes: Deno.PointerValue) => bigint;
-  g_bytes_unref: (bytes: Deno.PointerValue) => void;
-  g_variant_new_string: (str: BufferSource) => Deno.PointerValue;
-  g_variant_new_uint32: (value: number) => Deno.PointerValue;
-  g_variant_new_tuple: (children: Deno.PointerValue, nChildren: bigint) => Deno.PointerValue;
-  g_variant_get_child_value: (variant: Deno.PointerValue, index: bigint) => Deno.PointerValue;
-  g_variant_get_string: (variant: Deno.PointerValue, len: Deno.PointerValue) => Deno.PointerValue;
-  g_variant_get_uint32: (variant: Deno.PointerValue) => number;
-  g_variant_get_int32: (variant: Deno.PointerValue) => number;
-  g_variant_get_uint16: (variant: Deno.PointerValue) => number;
-  g_variant_get_type_string: (variant: Deno.PointerValue) => Deno.PointerValue;
-  g_variant_n_children: (variant: Deno.PointerValue) => bigint;
-  g_variant_type_hash: (type: Deno.PointerValue) => Deno.PointerValue;
-  g_variant_is_of_type: (variant: Deno.PointerValue, type: Deno.PointerValue) => boolean;
-  g_variant_unref: (variant: Deno.PointerValue) => void;
-  g_variant_ref: (variant: Deno.PointerValue) => Deno.PointerValue;
-  g_variant_ref_sink: (variant: Deno.PointerValue) => Deno.PointerValue;
-  g_set_prgname: (name: BufferSource) => void;
-  g_set_application_name: (name: BufferSource) => void;
-}
-
-interface GlibLib {
-  symbols: GlibSymbols;
-  close: () => void;
-}
-
-export const glib: GlibLib = Deno.dlopen(LIB_PATHS.glib, {
+const SYMBOLS = {
   g_main_loop_new: { parameters: ["pointer", "bool"], result: "pointer" },
   g_main_loop_run: { parameters: ["pointer"], result: "void" },
   g_main_loop_quit: { parameters: ["pointer"], result: "void" },
@@ -162,4 +118,9 @@ export const glib: GlibLib = Deno.dlopen(LIB_PATHS.glib, {
     parameters: ["buffer"],
     result: "void",
   },
-});
+} as const;
+
+export const glib: Deno.DynamicLibrary<typeof SYMBOLS> = Deno.dlopen(
+  LIB_PATHS.glib,
+  SYMBOLS,
+);

--- a/src/low/glib.ts
+++ b/src/low/glib.ts
@@ -2,125 +2,123 @@
 import "@sigma/deno-compat";
 import { LIB_PATHS } from "./paths/mod.ts";
 
-const SYMBOLS = {
-  g_main_loop_new: { parameters: ["pointer", "bool"], result: "pointer" },
-  g_main_loop_run: { parameters: ["pointer"], result: "void" },
-  g_main_loop_quit: { parameters: ["pointer"], result: "void" },
-  g_main_context_default: { parameters: [], result: "pointer" },
-  g_main_context_pending: { parameters: ["pointer"], result: "bool" },
-  g_main_context_iteration: {
-    parameters: ["pointer", "bool"],
-    result: "bool",
-  },
-  g_timeout_add: {
-    parameters: ["u32", "function", "pointer"],
-    result: "u32",
-  },
-  g_timeout_add_seconds: {
-    parameters: ["u32", "function", "pointer"],
-    result: "u32",
-  },
-  g_idle_add: {
-    parameters: ["function", "pointer"],
-    result: "u32",
-  },
-  g_source_remove: { parameters: ["u32"], result: "bool" },
-  g_free: { parameters: ["pointer"], result: "void" },
-  g_free_ptr: { name: "g_free", type: "pointer" },
-  g_strdup: { parameters: ["buffer"], result: "pointer" },
-  g_malloc0: { parameters: ["usize"], result: "pointer" },
-  g_unix_signal_add: {
-    parameters: ["i32", "function", "pointer"],
-    result: "u32",
-    optional: true,
-  },
-  g_bytes_new: {
-    parameters: ["buffer", "usize"],
-    result: "pointer",
-  },
-  g_bytes_get_data: {
-    parameters: ["pointer", "pointer"],
-    result: "pointer",
-  },
-  g_bytes_get_size: {
-    parameters: ["pointer"],
-    result: "usize",
-  },
-  g_bytes_unref: {
-    parameters: ["pointer"],
-    result: "void",
-  },
-  g_variant_new_string: {
-    parameters: ["buffer"],
-    result: "pointer",
-  },
-  g_variant_new_uint32: {
-    parameters: ["u32"],
-    result: "pointer",
-  },
-  g_variant_new_tuple: {
-    parameters: ["pointer", "usize"],
-    result: "pointer",
-  },
-  g_variant_get_child_value: {
-    parameters: ["pointer", "usize"],
-    result: "pointer",
-  },
-  g_variant_get_string: {
-    parameters: ["pointer", "pointer"],
-    result: "pointer",
-  },
-  g_variant_get_uint32: {
-    parameters: ["pointer"],
-    result: "u32",
-  },
-  g_variant_get_int32: {
-    parameters: ["pointer"],
-    result: "i32",
-  },
-  g_variant_get_uint16: {
-    parameters: ["pointer"],
-    result: "u16",
-  },
-  g_variant_get_type_string: {
-    parameters: ["pointer"],
-    result: "pointer",
-  },
-  g_variant_n_children: {
-    parameters: ["pointer"],
-    result: "usize",
-  },
-  g_variant_type_hash: {
-    parameters: ["pointer"],
-    result: "pointer",
-  },
-  g_variant_is_of_type: {
-    parameters: ["pointer", "pointer"],
-    result: "bool",
-  },
-  g_variant_unref: {
-    parameters: ["pointer"],
-    result: "void",
-  },
-  g_variant_ref: {
-    parameters: ["pointer"],
-    result: "pointer",
-  },
-  g_variant_ref_sink: {
-    parameters: ["pointer"],
-    result: "pointer",
-  },
-  g_set_prgname: {
-    parameters: ["buffer"],
-    result: "void",
-  },
-  g_set_application_name: {
-    parameters: ["buffer"],
-    result: "void",
-  },
-} as const;
-
-export const glib: Deno.DynamicLibrary<typeof SYMBOLS> = Deno.dlopen(
+export const glib = Deno.dlopen(
   LIB_PATHS.glib,
-  SYMBOLS,
+  {
+    g_main_loop_new: { parameters: ["pointer", "bool"], result: "pointer" },
+    g_main_loop_run: { parameters: ["pointer"], result: "void" },
+    g_main_loop_quit: { parameters: ["pointer"], result: "void" },
+    g_main_context_default: { parameters: [], result: "pointer" },
+    g_main_context_pending: { parameters: ["pointer"], result: "bool" },
+    g_main_context_iteration: {
+      parameters: ["pointer", "bool"],
+      result: "bool",
+    },
+    g_timeout_add: {
+      parameters: ["u32", "function", "pointer"],
+      result: "u32",
+    },
+    g_timeout_add_seconds: {
+      parameters: ["u32", "function", "pointer"],
+      result: "u32",
+    },
+    g_idle_add: {
+      parameters: ["function", "pointer"],
+      result: "u32",
+    },
+    g_source_remove: { parameters: ["u32"], result: "bool" },
+    g_free: { parameters: ["pointer"], result: "void" },
+    g_free_ptr: { name: "g_free", type: "pointer" },
+    g_strdup: { parameters: ["buffer"], result: "pointer" },
+    g_malloc0: { parameters: ["usize"], result: "pointer" },
+    g_unix_signal_add: {
+      parameters: ["i32", "function", "pointer"],
+      result: "u32",
+      optional: true,
+    },
+    g_bytes_new: {
+      parameters: ["buffer", "usize"],
+      result: "pointer",
+    },
+    g_bytes_get_data: {
+      parameters: ["pointer", "pointer"],
+      result: "pointer",
+    },
+    g_bytes_get_size: {
+      parameters: ["pointer"],
+      result: "usize",
+    },
+    g_bytes_unref: {
+      parameters: ["pointer"],
+      result: "void",
+    },
+    g_variant_new_string: {
+      parameters: ["buffer"],
+      result: "pointer",
+    },
+    g_variant_new_uint32: {
+      parameters: ["u32"],
+      result: "pointer",
+    },
+    g_variant_new_tuple: {
+      parameters: ["pointer", "usize"],
+      result: "pointer",
+    },
+    g_variant_get_child_value: {
+      parameters: ["pointer", "usize"],
+      result: "pointer",
+    },
+    g_variant_get_string: {
+      parameters: ["pointer", "pointer"],
+      result: "pointer",
+    },
+    g_variant_get_uint32: {
+      parameters: ["pointer"],
+      result: "u32",
+    },
+    g_variant_get_int32: {
+      parameters: ["pointer"],
+      result: "i32",
+    },
+    g_variant_get_uint16: {
+      parameters: ["pointer"],
+      result: "u16",
+    },
+    g_variant_get_type_string: {
+      parameters: ["pointer"],
+      result: "pointer",
+    },
+    g_variant_n_children: {
+      parameters: ["pointer"],
+      result: "usize",
+    },
+    g_variant_type_hash: {
+      parameters: ["pointer"],
+      result: "pointer",
+    },
+    g_variant_is_of_type: {
+      parameters: ["pointer", "pointer"],
+      result: "bool",
+    },
+    g_variant_unref: {
+      parameters: ["pointer"],
+      result: "void",
+    },
+    g_variant_ref: {
+      parameters: ["pointer"],
+      result: "pointer",
+    },
+    g_variant_ref_sink: {
+      parameters: ["pointer"],
+      result: "pointer",
+    },
+    g_set_prgname: {
+      parameters: ["buffer"],
+      result: "void",
+    },
+    g_set_application_name: {
+      parameters: ["buffer"],
+      result: "void",
+    },
+  },
 );

--- a/src/low/glib.ts
+++ b/src/low/glib.ts
@@ -2,123 +2,120 @@
 import "@sigma/deno-compat";
 import { LIB_PATHS } from "./paths/mod.ts";
 
-export const glib = Deno.dlopen(
-  LIB_PATHS.glib,
-  {
-    g_main_loop_new: { parameters: ["pointer", "bool"], result: "pointer" },
-    g_main_loop_run: { parameters: ["pointer"], result: "void" },
-    g_main_loop_quit: { parameters: ["pointer"], result: "void" },
-    g_main_context_default: { parameters: [], result: "pointer" },
-    g_main_context_pending: { parameters: ["pointer"], result: "bool" },
-    g_main_context_iteration: {
-      parameters: ["pointer", "bool"],
-      result: "bool",
-    },
-    g_timeout_add: {
-      parameters: ["u32", "function", "pointer"],
-      result: "u32",
-    },
-    g_timeout_add_seconds: {
-      parameters: ["u32", "function", "pointer"],
-      result: "u32",
-    },
-    g_idle_add: {
-      parameters: ["function", "pointer"],
-      result: "u32",
-    },
-    g_source_remove: { parameters: ["u32"], result: "bool" },
-    g_free: { parameters: ["pointer"], result: "void" },
-    g_free_ptr: { name: "g_free", type: "pointer" },
-    g_strdup: { parameters: ["buffer"], result: "pointer" },
-    g_malloc0: { parameters: ["usize"], result: "pointer" },
-    g_unix_signal_add: {
-      parameters: ["i32", "function", "pointer"],
-      result: "u32",
-      optional: true,
-    },
-    g_bytes_new: {
-      parameters: ["buffer", "usize"],
-      result: "pointer",
-    },
-    g_bytes_get_data: {
-      parameters: ["pointer", "pointer"],
-      result: "pointer",
-    },
-    g_bytes_get_size: {
-      parameters: ["pointer"],
-      result: "usize",
-    },
-    g_bytes_unref: {
-      parameters: ["pointer"],
-      result: "void",
-    },
-    g_variant_new_string: {
-      parameters: ["buffer"],
-      result: "pointer",
-    },
-    g_variant_new_uint32: {
-      parameters: ["u32"],
-      result: "pointer",
-    },
-    g_variant_new_tuple: {
-      parameters: ["pointer", "usize"],
-      result: "pointer",
-    },
-    g_variant_get_child_value: {
-      parameters: ["pointer", "usize"],
-      result: "pointer",
-    },
-    g_variant_get_string: {
-      parameters: ["pointer", "pointer"],
-      result: "pointer",
-    },
-    g_variant_get_uint32: {
-      parameters: ["pointer"],
-      result: "u32",
-    },
-    g_variant_get_int32: {
-      parameters: ["pointer"],
-      result: "i32",
-    },
-    g_variant_get_uint16: {
-      parameters: ["pointer"],
-      result: "u16",
-    },
-    g_variant_get_type_string: {
-      parameters: ["pointer"],
-      result: "pointer",
-    },
-    g_variant_n_children: {
-      parameters: ["pointer"],
-      result: "usize",
-    },
-    g_variant_type_hash: {
-      parameters: ["pointer"],
-      result: "pointer",
-    },
-    g_variant_is_of_type: {
-      parameters: ["pointer", "pointer"],
-      result: "bool",
-    },
-    g_variant_unref: {
-      parameters: ["pointer"],
-      result: "void",
-    },
-    g_variant_ref: {
-      parameters: ["pointer"],
-      result: "pointer",
-    },
-    g_variant_ref_sink: {
-      parameters: ["pointer"],
-      result: "pointer",
-    },
-    g_set_prgname: {
-      parameters: ["buffer"],
-      result: "void",
-    },
-    g_set_application_name: {
-      parameters: ["buffer"],
-      result: "void",
-    },
+export const glib = Deno.dlopen(LIB_PATHS.glib, {
+  g_main_loop_new: { parameters: ["pointer", "bool"], result: "pointer" },
+  g_main_loop_run: { parameters: ["pointer"], result: "void" },
+  g_main_loop_quit: { parameters: ["pointer"], result: "void" },
+  g_main_context_default: { parameters: [], result: "pointer" },
+  g_main_context_pending: { parameters: ["pointer"], result: "bool" },
+  g_main_context_iteration: {
+    parameters: ["pointer", "bool"],
+    result: "bool",
   },
-);
+  g_timeout_add: {
+    parameters: ["u32", "function", "pointer"],
+    result: "u32",
+  },
+  g_timeout_add_seconds: {
+    parameters: ["u32", "function", "pointer"],
+    result: "u32",
+  },
+  g_idle_add: {
+    parameters: ["function", "pointer"],
+    result: "u32",
+  },
+  g_source_remove: { parameters: ["u32"], result: "bool" },
+  g_free: { parameters: ["pointer"], result: "void" },
+  g_free_ptr: { name: "g_free", type: "pointer" },
+  g_strdup: { parameters: ["buffer"], result: "pointer" },
+  g_malloc0: { parameters: ["usize"], result: "pointer" },
+  g_unix_signal_add: {
+    parameters: ["i32", "function", "pointer"],
+    result: "u32",
+    optional: true,
+  },
+  g_bytes_new: {
+    parameters: ["buffer", "usize"],
+    result: "pointer",
+  },
+  g_bytes_get_data: {
+    parameters: ["pointer", "pointer"],
+    result: "pointer",
+  },
+  g_bytes_get_size: {
+    parameters: ["pointer"],
+    result: "usize",
+  },
+  g_bytes_unref: {
+    parameters: ["pointer"],
+    result: "void",
+  },
+  g_variant_new_string: {
+    parameters: ["buffer"],
+    result: "pointer",
+  },
+  g_variant_new_uint32: {
+    parameters: ["u32"],
+    result: "pointer",
+  },
+  g_variant_new_tuple: {
+    parameters: ["pointer", "usize"],
+    result: "pointer",
+  },
+  g_variant_get_child_value: {
+    parameters: ["pointer", "usize"],
+    result: "pointer",
+  },
+  g_variant_get_string: {
+    parameters: ["pointer", "pointer"],
+    result: "pointer",
+  },
+  g_variant_get_uint32: {
+    parameters: ["pointer"],
+    result: "u32",
+  },
+  g_variant_get_int32: {
+    parameters: ["pointer"],
+    result: "i32",
+  },
+  g_variant_get_uint16: {
+    parameters: ["pointer"],
+    result: "u16",
+  },
+  g_variant_get_type_string: {
+    parameters: ["pointer"],
+    result: "pointer",
+  },
+  g_variant_n_children: {
+    parameters: ["pointer"],
+    result: "usize",
+  },
+  g_variant_type_hash: {
+    parameters: ["pointer"],
+    result: "pointer",
+  },
+  g_variant_is_of_type: {
+    parameters: ["pointer", "pointer"],
+    result: "bool",
+  },
+  g_variant_unref: {
+    parameters: ["pointer"],
+    result: "void",
+  },
+  g_variant_ref: {
+    parameters: ["pointer"],
+    result: "pointer",
+  },
+  g_variant_ref_sink: {
+    parameters: ["pointer"],
+    result: "pointer",
+  },
+  g_set_prgname: {
+    parameters: ["buffer"],
+    result: "void",
+  },
+  g_set_application_name: {
+    parameters: ["buffer"],
+    result: "void",
+  },
+});

--- a/src/low/gtk4.ts
+++ b/src/low/gtk4.ts
@@ -103,6 +103,30 @@ export const gtk4 = Deno.dlopen(LIB_PATHS.gtk4, {
     parameters: ["pointer", "f64"],
     result: "void",
   },
+  gtk_adjustment_new: {
+    parameters: ["f64", "f64", "f64", "f64", "f64", "f64"],
+    result: "pointer",
+  },
+  gtk_adjustment_get_value: {
+    parameters: ["pointer"],
+    result: "f64",
+  },
+  gtk_scale_new: {
+    parameters: ["i32", "pointer"],
+    result: "pointer",
+  },
+  gtk_scale_set_draw_value: {
+    parameters: ["pointer", "bool"],
+    result: "void",
+  },
+  gtk_scale_set_digits: {
+    parameters: ["pointer", "i32"],
+    result: "void",
+  },
+  g_signal_connect: {
+    parameters: ["pointer", "buffer", "pointer", "pointer"],
+    result: "u64",
+  },
   gtk_dialog_new: { parameters: [], result: "pointer" },
   gtk_window_set_transient_for: {
     parameters: ["pointer", "pointer"],
@@ -695,34 +719,6 @@ export const gtk4 = Deno.dlopen(LIB_PATHS.gtk4, {
     result: "void",
   },
   gtk_level_bar_set_max_value: {
-    parameters: ["pointer", "f64"],
-    result: "void",
-  },
-  gtk_adjustment_new: {
-    parameters: ["f64", "f64", "f64", "f64", "f64", "f64"],
-    result: "pointer",
-  },
-  gtk_adjustment_get_value: {
-    parameters: ["pointer"],
-    result: "f64",
-  },
-  gtk_scale_new: {
-    parameters: ["i32", "pointer"],
-    result: "pointer",
-  },
-  gtk_scale_set_digits: {
-    parameters: ["pointer", "i32"],
-    result: "void",
-  },
-  gtk_scale_set_draw_value: {
-    parameters: ["pointer", "bool"],
-    result: "void",
-  },
-  gtk_range_get_value: {
-    parameters: ["pointer"],
-    result: "f64",
-  },
-  gtk_range_set_value: {
     parameters: ["pointer", "f64"],
     result: "void",
   },

--- a/src/low/gtk4.ts
+++ b/src/low/gtk4.ts
@@ -123,6 +123,10 @@ export const gtk4 = Deno.dlopen(LIB_PATHS.gtk4, {
     parameters: ["pointer", "i32"],
     result: "void",
   },
+  gtk_range_set_adjustment: {
+    parameters: ["pointer", "pointer"],
+    result: "void",
+  },
   gtk_dialog_new: { parameters: [], result: "pointer" },
   gtk_window_set_transient_for: {
     parameters: ["pointer", "pointer"],

--- a/src/low/gtk4.ts
+++ b/src/low/gtk4.ts
@@ -698,4 +698,32 @@ export const gtk4 = Deno.dlopen(LIB_PATHS.gtk4, {
     parameters: ["pointer", "f64"],
     result: "void",
   },
+  gtk_adjustment_new: {
+    parameters: ["f64", "f64", "f64", "f64", "f64", "f64"],
+    result: "pointer",
+  },
+  gtk_adjustment_get_value: {
+    parameters: ["pointer"],
+    result: "f64",
+  },
+  gtk_scale_new: {
+    parameters: ["i32", "pointer"],
+    result: "pointer",
+  },
+  gtk_scale_set_digits: {
+    parameters: ["pointer", "i32"],
+    result: "void",
+  },
+  gtk_scale_set_draw_value: {
+    parameters: ["pointer", "bool"],
+    result: "void",
+  },
+  gtk_range_get_value: {
+    parameters: ["pointer"],
+    result: "f64",
+  },
+  gtk_range_set_value: {
+    parameters: ["pointer", "f64"],
+    result: "void",
+  },
 });

--- a/src/low/gtk4.ts
+++ b/src/low/gtk4.ts
@@ -123,10 +123,6 @@ export const gtk4 = Deno.dlopen(LIB_PATHS.gtk4, {
     parameters: ["pointer", "i32"],
     result: "void",
   },
-  g_signal_connect: {
-    parameters: ["pointer", "buffer", "pointer", "pointer"],
-    result: "u64",
-  },
   gtk_dialog_new: { parameters: [], result: "pointer" },
   gtk_window_set_transient_for: {
     parameters: ["pointer", "pointer"],


### PR DESCRIPTION
## Summary
- Add brightness control app for external monitors via DDC/CI protocol
- Uses ddccontrol D-Bus service for privileged brightness control
- Supports multiple monitors with navigation

## Changes
- New: `examples/brightness-control.ts` - GTK app with brightness slider
- New: D-Bus proxy methods for ddccontrol service (callSyncWithStrings, callSyncWithMixed)
- New: GVariant helpers for parsing D-Bus responses
- New: Scale widget with Adjustment for GTK4
- Fix: Proper FFI bindings for gtk_adjustment_new, gtk_range_set_adjustment, g_signal_connect_data
- Fix: Bun compatibility for empty array buffers in FFI

## Testing
- Works with deno, bun, and node
- Tested with MSI MP223 external monitor